### PR TITLE
Support Python 3.4 (trusty)

### DIFF
--- a/lib/charms/layer/options.py
+++ b/lib/charms/layer/options.py
@@ -15,7 +15,8 @@ def get(section=None, option=None, layer_file=_DEFAULT_FILE):
 
     layer_file = (_CHARM_PATH / layer_file).resolve()
     if layer_file not in _CACHE:
-        _CACHE[layer_file] = yaml.safe_load(layer_file.read_text())
+        with layer_file.open() as fp:
+            _CACHE[layer_file] = yaml.safe_load(fp.read())
 
     data = _CACHE[layer_file].get('options', {})
     if section:


### PR DESCRIPTION
`Path.read_text()` was added in 3.5, but trusty only has 3.4